### PR TITLE
fix: Update cronos service name to use in rpc shared config

### DIFF
--- a/rpc-shared.yml
+++ b/rpc-shared.yml
@@ -1,6 +1,6 @@
 # To be used with cronos.yml
 services:
-  cronos-node:
+  cronos:
     ports:
       - ${RPC_PORT:-8545}:${RPC_PORT:-8545}/tcp
       - ${WS_PORT:-8546}:${WS_PORT:-8546}/tcp


### PR DESCRIPTION
When attempting to use `cronos-docker` from the scratch I've ran into the error,

```
...
service "cronos-node" has neither an image nor a build context specified: invalid compose project
./ethd terminated with exit code 1 on line 135
This happened during ./ethd update 
```

To fix that I've changed `cronos` service name in `rpc-shared.yml` file.

Thanks